### PR TITLE
Move to `Git.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.1.1"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-GitCommand = "49b5b516-ca3f-4003-a081-42bdcf55082d"
+Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -15,6 +15,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.6"
-GitCommand = "2.1"
+Git = "1"
 JSON3 = "1"
 Scratch = "1"

--- a/src/PackageCompatUI.jl
+++ b/src/PackageCompatUI.jl
@@ -75,8 +75,10 @@ function compat_ui(;pagesize = 20, dates = true)
 end
 
 function gitcmd(repo)
-    (x...) -> GitCommand.git() do git
-        readlines(Cmd([git, "-C", repo, x...]))
+    function (x...)
+        cmd = `$(GitCommand.git()) -C $(repo)`
+        append!(cmd.exec, x...)
+        readlines(cmd)
     end
 end
 


### PR DESCRIPTION
`GitCommand.jl` now lives in `Git.jl`, with a slightly different syntax.  Added
bonus: it's thread-safe.