### PR TITLE
Work around a bug in TerminalMenus.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PackageCompatUI"
 uuid = "65465c31-362d-417a-a2f0-7fa38ae507b9"
 authors = ["Gunnar Farnebäck <gunnar.farneback@contextvision.se>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/menu.jl
+++ b/src/menu.jl
@@ -165,6 +165,20 @@ function load_state!(menu::Menu, mode::Symbol)
 end
 
 function writeline(buf::IOBuffer, menu::Menu, idx::Int, iscursor::Bool)
+    # This is a workaround for
+    # https://github.com/JuliaLang/julia/pull/48173.
+    #
+    # It can be removed when no Julia versions before 1.9 (probably)
+    # are supported.
+    #
+    # Note that while this workaround avoids indexing out of bounds
+    # and makes the menu work correctly, the result is still less than
+    # ideal with the options needlessly jumping around.
+    if idx <= 0
+        print(buf, "")
+        return
+    end
+
     if menu.mode == :-
         print(buf, menu.options[idx])
     else


### PR DESCRIPTION
Workaround for https://github.com/JuliaLang/julia/pull/48173. The visual result isn't amazing but it avoids indexing out of bounds and works correctly.

Fixes #15.